### PR TITLE
Roxygen

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Title: Quasi Variances for Factor Effects in Statistical Models
 Author: David Firth
 Maintainer: David Firth <d.firth@warwick.ac.uk>
 URL: https://davidfirth.github.io/qvcalc/
+BugReports: https://github.com/DavidFirth/qvcalc/issues
 Description: Functions to compute quasi variances and associated measures of approximation error.
 Suggests: 
     relimp,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,5 +13,5 @@ Suggests:
 Enhances: psychotools, survival
 License: GPL-2 | GPL-3
 Config/testthat/edition: 3
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/R/qvcalc.R
+++ b/R/qvcalc.R
@@ -95,17 +95,15 @@
 #'
 #' Firth, D. (2000) Quasi-variances in Xlisp-Stat and on the web.
 #' \emph{Journal of Statistical Software} \bold{5.4}, 1--13.
-#' c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-#' "10.18637/jss.v005.i04")\Sexpr{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
+#' \Sexpr[results=rd]{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
 #'
 #' Firth, D. (2003) Overcoming the reference category problem in the
 #' presentation of statistical models. \emph{Sociological Methodology}
-#' \bold{33}, 1--18. c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-#' "10.1111/j.0081-1750.2003.t01-1-00125.x")\Sexpr{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
+#' \bold{33}, 1--18. \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
 #'
 #' Firth, D. and de Mezezes, R. X. (2004) Quasi-variances.  \emph{Biometrika}
-#' \bold{91}, 65--80. c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-#' "10.1093/biomet/91.1.65")\Sexpr{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
+#' \bold{91}, 65--80. \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
+
 #'
 #' McCullagh, P. and Nelder, J. A. (1989) \emph{Generalized Linear Models}.
 #' London: Chapman and Hall.
@@ -328,10 +326,12 @@ indentPrint <- function(object, indent = 4, ...){
     indent <- paste(rep(" ", indent), sep = "", collapse = "")
     cat(paste(indent, zz, sep = ""), sep = "\n")}
 
+#' @export
 print.qv <- function(x, ...){
     print(x$qvframe)
 }
 
+#' @export
 summary.qv <- function(object, ...)
 {
     if (!is.null(object$modelcall))
@@ -388,17 +388,14 @@ summary.qv <- function(object, ...)
 #'
 #' Firth, D. (2000) Quasi-variances in Xlisp-Stat and on the web.
 #' \emph{Journal of Statistical Software} \bold{5.4}, 1--13.
-#' c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-#' "10.18637/jss.v005.i04")\Sexpr{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
+#' \Sexpr[results=rd]{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
 #'
 #' Firth, D. (2003) Overcoming the reference category problem in the
 #' presentation of statistical models. \emph{Sociological Methodology}
-#' \bold{33}, 1--18. c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-#' "10.1111/j.0081-1750.2003.t01-1-00125.x")\Sexpr{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
+#' \bold{33}, 1--18. \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
 #'
 #' Firth, D. and Mezezes, R. X. de (2004) Quasi-variances.  \emph{Biometrika}
-#' \bold{91}, 65--80.  c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-#' "10.1093/biomet/91.1.65")\Sexpr{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
+#' \bold{91}, 65--80.  \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
 #'
 #' McCullagh, P. and Nelder, J. A. (1989) \emph{Generalized Linear Models}.
 #' London: Chapman and Hall.

--- a/R/worstErrors.R
+++ b/R/worstErrors.R
@@ -1,10 +1,10 @@
 #' Accuracy of a Quasi-variance Approximation
-#' 
+#'
 #' Computes the worst relative error, among all contrasts, for the standard
 #' error as derived from a set of quasi variances.  For details of the method
 #' see Menezes (1999) or Firth and Menezes (2004).
-#' 
-#' 
+#'
+#'
 #' @param qv.object An object of class \code{qv}
 #' @return A numeric vector of length 2, the worst negative relative error and
 #' the worst positive relative error.
@@ -12,18 +12,17 @@
 #' @seealso \code{\link{qvcalc}}
 #' @references Firth, D. and Mezezes, R. X. de (2004) Quasi-variances.
 #' \emph{Biometrika} \bold{91}, 69--80.
-#' c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-#' "10.1093/biomet/91.1.65")\Sexpr{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
-#' 
+#' \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
+#'
 #' McCullagh, P. and Nelder, J. A. (1989) \emph{Generalized Linear Models}.
 #' London: Chapman and Hall.
-#' 
+#'
 #' Menezes, R. X. (1999) More useful standard errors for group and factor
 #' effects in generalized linear models.  \emph{D.Phil. Thesis}, Department of
 #' Statistics, University of Oxford.
 #' @keywords regression models
 #' @examples
-#' 
+#'
 #' ##  Overdispersed Poisson loglinear model for ship damage data
 #' ##  from McCullagh and Nelder (1989), Sec 6.3.2
 #' library(MASS)
@@ -31,12 +30,12 @@
 #' ships$year <- as.factor(ships$year)
 #' ships$period <- as.factor(ships$period)
 #' shipmodel <- glm(formula = incidents ~ type + year + period,
-#'     family = quasipoisson, 
+#'     family = quasipoisson,
 #'     data = ships, subset = (service > 0), offset = log(service))
 #' shiptype.qvs <- qvcalc(shipmodel, "type")
 #' summary(shiptype.qvs, digits = 4)
 #' worstErrors(shiptype.qvs)
-#' 
+#'
 #' @export worstErrors
 worstErrors <- function(qv.object)
 {

--- a/man/plot.qv.Rd
+++ b/man/plot.qv.Rd
@@ -75,17 +75,14 @@ Medicine} \bold{10}, 1025--1035.
 
 Firth, D. (2000) Quasi-variances in Xlisp-Stat and on the web.
 \emph{Journal of Statistical Software} \bold{5.4}, 1--13.
-c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-"10.18637/jss.v005.i04")\Sexpr{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
+\Sexpr[results=rd]{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
 
 Firth, D. (2003) Overcoming the reference category problem in the
 presentation of statistical models. \emph{Sociological Methodology}
-\bold{33}, 1--18. c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-"10.1111/j.0081-1750.2003.t01-1-00125.x")\Sexpr{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
+\bold{33}, 1--18. \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
 
 Firth, D. and Mezezes, R. X. de (2004) Quasi-variances.  \emph{Biometrika}
-\bold{91}, 65--80.  c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-"10.1093/biomet/91.1.65")\Sexpr{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
+\bold{91}, 65--80.  \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
 
 McCullagh, P. and Nelder, J. A. (1989) \emph{Generalized Linear Models}.
 London: Chapman and Hall.

--- a/man/qvcalc.Rd
+++ b/man/qvcalc.Rd
@@ -202,17 +202,14 @@ Medicine} \bold{10}, 1025--1035.
 
 Firth, D. (2000) Quasi-variances in Xlisp-Stat and on the web.
 \emph{Journal of Statistical Software} \bold{5.4}, 1--13.
-c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-"10.18637/jss.v005.i04")\Sexpr{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
+\Sexpr[results=rd]{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}
 
 Firth, D. (2003) Overcoming the reference category problem in the
 presentation of statistical models. \emph{Sociological Methodology}
-\bold{33}, 1--18. c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-"10.1111/j.0081-1750.2003.t01-1-00125.x")\Sexpr{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
+\bold{33}, 1--18. \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1111/j.0081-1750.2003.t01-1-00125.x")}
 
 Firth, D. and de Mezezes, R. X. (2004) Quasi-variances.  \emph{Biometrika}
-\bold{91}, 65--80. c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-"10.1093/biomet/91.1.65")\Sexpr{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
+\bold{91}, 65--80. \Sexpr[results=rd]{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
 
 McCullagh, P. and Nelder, J. A. (1989) \emph{Generalized Linear Models}.
 London: Chapman and Hall.

--- a/man/worstErrors.Rd
+++ b/man/worstErrors.Rd
@@ -27,7 +27,7 @@ data(ships)
 ships$year <- as.factor(ships$year)
 ships$period <- as.factor(ships$period)
 shipmodel <- glm(formula = incidents ~ type + year + period,
-    family = quasipoisson, 
+    family = quasipoisson,
     data = ships, subset = (service > 0), offset = log(service))
 shiptype.qvs <- qvcalc(shipmodel, "type")
 summary(shiptype.qvs, digits = 4)
@@ -37,8 +37,7 @@ worstErrors(shiptype.qvs)
 \references{
 Firth, D. and Mezezes, R. X. de (2004) Quasi-variances.
 \emph{Biometrika} \bold{91}, 69--80.
-c("\\Sexpr[results=rd]{tools:::Rd_expr_doi(\"#1\")}",
-"10.1093/biomet/91.1.65")\Sexpr{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
+\Sexpr[results=rd]{tools:::Rd_expr_doi("10.1093/biomet/91.1.65")}
 
 McCullagh, P. and Nelder, J. A. (1989) \emph{Generalized Linear Models}.
 London: Chapman and Hall.


### PR DESCRIPTION
Overall it was a few missing } in the mix and I just used `\Sexpr[results=rd]{tools:::Rd_expr_doi("10.18637/jss.v005.i04")}` not the `\\#1` and removed the non-Rd example output